### PR TITLE
Add generic X/Y coordinate delegate so selector can be used as a virtual joystick

### DIFF
--- a/Source/ColorWheelPlugin/Private/ColorWidget.cpp
+++ b/Source/ColorWheelPlugin/Private/ColorWidget.cpp
@@ -12,7 +12,8 @@ TSharedRef<SWidget> UColorWidget::RebuildWidget()
                 .HueCircle(&HueCircle)
                 .OnMouseCaptureBegin_UObject(this, &UColorWidget::MouseDown)
                 .OnMouseCaptureEnd_UObject(this, &UColorWidget::MouseUp)
-                .OnValueChanged(FOnLinearColorValueChanged::CreateUObject(this, &UColorWidget::OnValueChanged));
+                .OnValueChanged(FOnLinearColorValueChanged::CreateUObject(this, &UColorWidget::OnValueChanged))
+                .OnPositionChanged(FOnPositionChanged::CreateUObject(this, &UColorWidget::OnPositionUpdated));
 	
     return ColorWheel.ToSharedRef();
 }
@@ -28,6 +29,13 @@ void UColorWidget::OnValueChanged(FLinearColor NewValue)
 {
     Color = NewValue.HSVToLinearRGB();
     OnColorChanged.Broadcast(Color);
+}
+
+
+void UColorWidget::OnPositionUpdated(FVector2D NewPosition)
+{
+    //UE_LOG(LogTemp, Warning, TEXT("D - X: %f - Y: %f"), NewPosition.X, NewPosition.Y)
+    OnPositionChanged.Broadcast(NewPosition);
 }
 
 /// Main Functions ///

--- a/Source/ColorWheelPlugin/Private/SWColorWheel.cpp
+++ b/Source/ColorWheelPlugin/Private/SWColorWheel.cpp
@@ -16,6 +16,7 @@ void SWColorWheel::Construct(const FArguments& InArgs)
 	OnMouseCaptureBegin = InArgs._OnMouseCaptureBegin;
 	OnMouseCaptureEnd = InArgs._OnMouseCaptureEnd;
 	OnValueChanged = InArgs._OnValueChanged;
+	OnPositionChanged = InArgs._OnPositionChanged;
 }
 
 void SWColorWheel::SetColorAndOpacity(FLinearColor InColorAndOpacity, TEnumAsByte<EWheelBrushTarget> TargetBrush)
@@ -138,6 +139,10 @@ bool SWColorWheel::ProcessMouseAction(const FGeometry& MyGeometry, const FPointe
 {
 	const FVector2D LocalMouseCoordinate = MyGeometry.AbsoluteToLocal(MouseEvent.GetScreenSpacePosition());
 	const FVector2D RelativePositionFromCenter = (2.0f * LocalMouseCoordinate - MyGeometry.GetLocalSize()) / (MyGeometry.GetLocalSize() - SelectorImage->ImageSize);
+	
+	OnPositionChanged.ExecuteIfBound(FVector2D(FMath::Clamp(RelativePositionFromCenter.X, -1.0, 1.0), -1.0 * FMath::Clamp(RelativePositionFromCenter.Y, -1.0, 1.0)));
+	//UE_LOG(LogTemp, Warning, TEXT("X: %f - Y: %f"), RelativePositionFromCenter.X, RelativePositionFromCenter.Y)
+	
 	const float RelativeRadius = RelativePositionFromCenter.Size();
 
 	if (RelativeRadius <= 1.0f || bProcessWhenOutsideColorWheel)

--- a/Source/ColorWheelPlugin/Public/ColorWidget.h
+++ b/Source/ColorWheelPlugin/Public/ColorWidget.h
@@ -22,6 +22,8 @@ class SWColorWheel;
  */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FColorChangedEvent, const FLinearColor&, NewColor);
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPositionUpdatedEvent, const FVector2D&, NewPosition);
+
 /** Delegate: Broadcasted when the mouse is down on the Wheel. */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FMouseDownEvent);
 
@@ -56,9 +58,13 @@ public:
 	|                                  Events                                     |
 	\============================================================================*/
 	
-	/** Event called when value is changed */
+	/** Event called when color value is changed */
 	UPROPERTY(BlueprintAssignable, Category="Color Wheel|Event")
 	FColorChangedEvent OnColorChanged;
+
+	/** Event called when value is changed */
+	UPROPERTY(BlueprintAssignable, Category = "Color Wheel|Event")
+	FPositionUpdatedEvent OnPositionChanged;
 
 	/** Event called when the mouse is being pressed on the wheel */
 	UPROPERTY(BlueprintAssignable, Category="Color Wheel|Event")
@@ -134,6 +140,8 @@ private:
 
 	// Callback Function: Handles the broadcasting of the delegate once a color changes.
 	void OnValueChanged(FLinearColor NewValue);
+
+	void OnPositionUpdated(FVector2D NewPosition);
 
 	// Callback Function: Handles the broadcasting for when the Mouse is lifted from the wheel.
 	inline void MouseUp() { OnMouseUp.Broadcast(); };

--- a/Source/ColorWheelPlugin/Public/SWColorWheel.h
+++ b/Source/ColorWheelPlugin/Public/SWColorWheel.h
@@ -20,6 +20,8 @@ class FPaintArgs;
 class FSlateWindowElementList;
 struct FSlateBrush;
 
+DECLARE_DELEGATE_OneParam(FOnPositionChanged, FVector2D)
+
 // Used for some of the Color wheels UFUNCTIONS to specify the target brush.
 UENUM()
 enum EWheelBrushTarget
@@ -50,6 +52,7 @@ public:
         , _OnMouseCaptureBegin()
         , _OnMouseCaptureEnd()
         , _OnValueChanged()
+        , _OnPositionChanged()
         { }
 
         /// Attributes ///
@@ -75,6 +78,9 @@ public:
 
         /** Invoked when a new value is selected on the color wheel. */
         SLATE_EVENT(FOnLinearColorValueChanged, OnValueChanged)
+
+        /** Invoked when a new value is selected on the widget wheel. */
+        SLATE_EVENT(FOnPositionChanged, OnPositionChanged);
 
     SLATE_END_ARGS()
 
@@ -153,5 +159,8 @@ private:
 
     /** Invoked when a new value is selected on the color wheel. */
     FOnLinearColorValueChanged OnValueChanged;
+
+	/** Invoked when a new value is selected on the color wheel. */
+    FOnPositionChanged OnPositionChanged;
     
 };


### PR DESCRIPTION
This just extends out the functionality you already have available and adds a generic delegate to spit out X/Y coordinates allowing this to be used for more than just picking a color :)

Thanks for making this btw!